### PR TITLE
use PATH order to avoid where command return multiple result

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ if (argv.length) {
   };
   childProcess.exec(
     process.platform === 'win32' ?
-      'where bash' : 'which bash',
+      'echo bash' : 'which bash',
     how,
     function (err, bash, stderr) {
       if (err) {


### PR DESCRIPTION
on Windows, where command could return multiple line of result, when will fail following spawn call
just call "bash" by PATH order could be better